### PR TITLE
lifelines search term stuff

### DIFF
--- a/molgenis-omx-protocolviewer/src/test/java/org/molgenis/omx/protocolviewer/ProtocolViewerControllerTest.java
+++ b/molgenis-omx-protocolviewer/src/test/java/org/molgenis/omx/protocolviewer/ProtocolViewerControllerTest.java
@@ -5,11 +5,19 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 
+import org.mockito.ArgumentCaptor;
 import org.molgenis.catalog.CatalogFolder;
 import org.molgenis.catalog.UnknownCatalogException;
+import org.molgenis.data.QueryRule;
+import org.molgenis.data.QueryRule.Operator;
+import org.molgenis.data.support.QueryImpl;
 import org.molgenis.framework.server.MolgenisSettings;
 import org.molgenis.omx.protocolviewer.ProtocolViewerController.SelectedItemsResponse;
+import org.molgenis.search.Hit;
+import org.molgenis.search.SearchRequest;
+import org.molgenis.search.SearchResult;
 import org.molgenis.search.SearchService;
 import org.molgenis.study.StudyDefinition;
 import org.molgenis.study.UnknownStudyDefinitionException;
@@ -21,6 +29,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.io.Resources;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -72,5 +81,36 @@ public class ProtocolViewerControllerTest
 
 		Assert.assertEquals(gson.toJson(response), Resources.toString(
 				Resources.getResource("org/molgenis/omx/protocolviewer/selectionResponse.json"), Charsets.UTF_8));
+	}
+
+	@Test
+	public void testSearchSingleTerm()
+	{
+		ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+		SearchResult result = new SearchResult(0L, Collections.<Hit> emptyList());
+		when(searchService.search(captor.capture())).thenReturn(result);
+		protocolViewerController.searchItems(ImmutableMap.<String, Object> of("catalogId", "257811", "queryString",
+				"DEMO4A"));
+		Assert.assertEquals(
+				captor.getValue(),
+				new SearchRequest("protocolTree-257811", new QueryImpl(Arrays.asList(new QueryRule(Operator.SEARCH,
+						"DEMO4A"))).pageSize(Integer.MAX_VALUE), null));
+	}
+
+	@Test
+	public void testSearchMultipleSpaces()
+	{
+		ArgumentCaptor<SearchRequest> captor = ArgumentCaptor.forClass(SearchRequest.class);
+		SearchResult result = new SearchResult(0L, Collections.<Hit> emptyList());
+		when(searchService.search(captor.capture())).thenReturn(result);
+		protocolViewerController.searchItems(ImmutableMap.<String, Object> of("catalogId", "257811", "queryString",
+				"DEMO  4A"));
+		QueryRule nestedQuery = new QueryRule(Operator.NESTED, Arrays.asList(new QueryRule(Operator.SEARCH, "DEMO"),
+				QueryRule.AND, new QueryRule(Operator.SEARCH, "4A")));
+		Assert.assertEquals(
+				captor.getValue(),
+				new SearchRequest("protocolTree-257811", new QueryImpl(Arrays.asList(
+						nestedQuery, QueryRule.OR, new QueryRule(
+								Operator.SEARCH, "DEMO  4A"))).pageSize(Integer.MAX_VALUE), null));
 	}
 }


### PR DESCRIPTION
- Split search term on whitespace.
- Nest the OR query before adding the AND.
- Only add the AND if the search term was split.
- Add unit tests.